### PR TITLE
remove inapplicable “Remember” in FAQ

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -174,7 +174,7 @@ API can keep everyone and everything running smoothly.
 
 As soon as you realize that you've broken the Semantic Versioning spec, fix
 the problem and release a new minor version that corrects the problem and
-restores backwards compatibility. Remember, it is unacceptable to modify
+restores backwards compatibility. It remains unacceptable to modify
 versioned releases, even under this circumstance. If it's appropriate,
 document the offending version and inform your users of the problem so that
 they are aware of the offending version.


### PR DESCRIPTION
> ### What do I do if I accidentally release a backwards incompatible change as a minor version?
> 
> As soon as you realize that you've broken the Semantic Versioning spec, fix the problem and release a new minor version that corrects the problem and restores backwards compatibility. **Remember**, it is unacceptable to modify versioned releases, even under this circumstance. If it's appropriate, document the offending version and inform your users of the problem so that they are aware of the offending version.

I think “Remember” shouldn’t be there. Yes, I do remember this:

> Once a versioned package has been released, the contents of that version MUST NOT be modified.

But I also remember this:

> Major version X (X.y.z | X > 0) MUST be incremented if any backwards incompatible changes are introduced to the public API.

Those are both MUSTs. They are equally important. The premise of the question is that we’ve already broken one MUST – we’re in unknown, unregulated territory. It is not obvious that getting back to the spec shouldn’t involve breaking another MUST. “Remember” implies that it should have been obvious, but I think isn’t obvious – that sentence in the FAQ is new information, not a reminder. Thus, I think that sentence should be this:

> It is unacceptable to modify versioned releases, even under this circumstance.

or perhaps this, which more explicitly acknowledges that the decision could have been made either way:

> It **remains** unacceptable to modify versioned releases, even under this circumstance.
