### PR TITLE
Updated to RC2, with new definition for build metadata

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -80,19 +80,17 @@ Pre-release versions satisfy but have a lower precedence than the associated
 normal version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7,
 1.0.0-x.7.z.92.
 
-1. Unique build metadata MAY be denoted by appending a plus `+` and a series of
-dot separated identifiers immediately following the patch or pre-release
-version. Identifiers MUST be comprised of only ASCII alphanumerics and hyphens 
-[0-9AsZa-z\-]. Build metadata does not affect the version of the public API. It
-is primarily used to uniquely identify a specific build of a package. Thus 
-the Semantic Versioning specification intentionally omits precedence rule
-definitions for comparing two versions where only build metadata is different.
-Furthermore, this specification does not define precedence rules for comparing
-a version with build metadata to a version without build metadata. Specific
-implementations of Semantic Versioning MAY define their own precedence rules
-for those scenarios, but due to the lack of precedence defined within the
-specification, consumers SHOULD NOT rely on build metadata when taking
-dependencies on packages.
+1. Build metadata MAY be denoted by appending a plus `+` and an identifier
+immediately following the patch or pre-release version. These optional
+identifiers MUST be comprised of only ASCII alphanumerics, hyphens, and dots
+[0-9A-Za-z\-\.]. Build metadata only defines uniqueness to allow multiple
+builds of a version to coexist, thus two versions that differ only by build
+metadata (or lack thereof) MUST be compatible. Moreover, the Semantic
+Versioning specification cannot define precedence among multiple versions
+that differ only by build metadata (or lack thereof). Specific implementations
+of Semantic Versioning MAY define their own precedence rules however, but due
+to the lack of precedence defined within the specification itself, consumers
+SHOULD NOT rely on build metadata when taking dependencies on packages.
 
 1. Precedence MUST be calculated by separating the version into major, minor,
 patch, pre-release, and build identifiers in that order. Major, minor, and


### PR DESCRIPTION
Related to #61.

I omitted the free-form metadata component, as I wasn't sure what character set to allow within it, but I wanted to proceed with the new build metadata definition.
