### PR TITLE
Build metadata identifier

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -81,7 +81,7 @@ version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92.
 
 1. Build metadata MAY be denoted by appending a plus sign and a series of dot 
 separated identifiers immediately following the patch or pre-release version. 
-Identifiers MUST comprise only ASCII alphanumerics and hyphen[0-9A-Za-z-]. 
+Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-]. 
 Build metadata SHOULD be ignored when determining version precedence. Thus two
 packages with the same version, but different build metadata are considered to
 be the same version. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700, 

--- a/semver.md
+++ b/semver.md
@@ -79,18 +79,12 @@ MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-]. Pre-release
 versions satisfy but have a lower precedence than the associated normal
 version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92.
 
-1. Unique build metadata MAY be denoted by appending a plus `+` and a series of
-dot separated identifiers immediately following the patch or pre-release
-version. While identifiers MUST be comprised of only ASCII alphanumerics and
-hyphens [0-9A-Za-z\-], their values only define uniqueness. The Semantic
-Versioning specation intentionally omits precedence rule definitions for
-comparing two versions where only build metadata is different. Furthermore,
-this specification does not define precedence rules for comparing a version
-with build metadata to a version without build metadata. Specific
-implementations of Semantic Versioning MAY define their own precedence rules
-for those scenarios, but due to the lack of precedence defined within the
-specification, consumers SHOULD NOT rely on build metadata when taking
-dependencies on packages.
+1. Build metadata MAY be denoted by appending a plus + and a series of dot 
+separated identifiers immediately following the patch or pre-release version. 
+Identifiers MUST be comprised of only ASCII alphanumerics and hyphen 
+[0-9A-Za-z-]. Build metadata SHOULD be ignored when determining version 
+precedence. Thus two packages with the same version, but different build 
+metadata are considered to be the same version.
 
 1. Precedence MUST be calculated by separating the version into major, minor,
 patch, pre-release, and build identifiers in that order. Major, minor, and

--- a/semver.md
+++ b/semver.md
@@ -81,11 +81,11 @@ version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92.
 
 1. Build metadata MAY be denoted by appending a plus sign and a series of dot 
 separated identifiers immediately following the patch or pre-release version. 
-Identifiers MUST be comprised of only ASCII alphanumerics and hyphen 
-[0-9A-Za-z-]. Build metadata SHOULD be ignored when determining version 
-precedence. Thus two packages with the same version, but different build 
-metadata are considered to be the same version. Examples: 1.0.0-alpha+001, 
-1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85.
+Identifiers MUST comprise only ASCII alphanumerics and hyphen[0-9A-Za-z-]. 
+Build metadata SHOULD be ignored when determining version precedence. Thus two
+packages with the same version, but different build metadata are considered to
+be the same version. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700, 
+1.0.0-beta+exp.sha.5114f85.
 
 1. Precedence MUST be calculated by separating the version into major, minor,
 patch and pre-release identifiers in that order (Build metadata does not figure 

--- a/semver.md
+++ b/semver.md
@@ -87,14 +87,14 @@ precedence. Thus two packages with the same version, but different build
 metadata are considered to be the same version.
 
 1. Precedence MUST be calculated by separating the version into major, minor,
-patch, pre-release, and build identifiers in that order. Major, minor, and
-patch versions are always compared numerically. Pre-release precedence MUST be
-determined by comparing each dot separated identifier as follows: identifiers
-consisting of only digits are compared numerically and identifiers with
-letters or hyphens are compared lexically in ASCII sort order. Numeric
-identifiers always have lower precedence than non-numeric identifiers.
-Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-beta.2 < 1.0.0-beta.11 <
-1.0.0-rc.1 < 1.0.0.
+patch and pre-release identifiers in that order (Build metadata does not figure 
+into precedence). Major, minor, and patch versions are always compared 
+numerically. Pre-release precedence MUST be determined by comparing each dot 
+separated identifier as follows: identifiers consisting of only digits are 
+compared numerically and identifiers with letters or hyphens are compared 
+lexically in ASCII sort order. Numeric identifiers always have lower precedence
+than non-numeric identifiers. Example: 1.0.0-alpha < 1.0.0-alpha.1 < 
+1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
 
 Why Use Semantic Versioning?
 ----------------------------

--- a/semver.md
+++ b/semver.md
@@ -82,7 +82,7 @@ version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92.
 1. Unique build metadata MAY be denoted by appending a plus `+` and a series of
 dot separated identifiers immediately following the patch or pre-release
 version. While identifiers MUST be comprised of only ASCII alphanumerics and
-hyphens [0-9A-Za-z\\-], their values only define uniqueness. The Semantic
+hyphens [0-9A-Za-z\-], their values only define uniqueness. The Semantic
 Versioning specation intentionally omits precedence rule definitions for
 comparing two versions where only build metadata is different. Furthermore,
 this specification does not define precedence rules for comparing a version

--- a/semver.md
+++ b/semver.md
@@ -1,4 +1,4 @@
-Semantic Versioning 2.0.0-rc.1
+Semantic Versioning 2.0.0-rc.2
 ==============================
 
 In the world of software management there exists a dread place called
@@ -79,22 +79,28 @@ MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-]. Pre-release
 versions satisfy but have a lower precedence than the associated normal
 version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92.
 
-1. A build version MAY be denoted by appending a plus sign and a series of dot
-separated identifiers immediately following the patch version or pre-release
-version. Identifiers MUST be comprised of only ASCII alphanumerics and hyphen
-[0-9A-Za-z-]. Build versions satisfy and have a higher precedence than the
-associated normal version. Examples: 1.0.0+build.1, 1.3.7+build.11.e0f985a.
+1. Unique build metadata MAY be denoted by appending a plus `+` and a series of
+dot separated identifiers immediately following the patch or pre-release
+version. While identifiers MUST be comprised of only ASCII alphanumerics and
+hyphens [0-9A-Za-z\\-], their values only define uniqueness. The Semantic
+Versioning specation intentionally omits precedence rule definitions for
+comparing two versions where only build metadata is different. Furthermore,
+this specification does not define precedence rules for comparing a version
+with build metadata to a version without build metadata. Specific
+implementations of Semantic Versioning MAY define their own precedence rules
+for those scenarios, but due to the lack of precedence defined within the
+specification, consumers SHOULD NOT rely on build metadata when taking
+dependencies on packages.
 
 1. Precedence MUST be calculated by separating the version into major, minor,
 patch, pre-release, and build identifiers in that order. Major, minor, and
-patch versions are always compared numerically. Pre-release and build version
-precedence MUST be determined by comparing each dot separated identifier as
-follows: identifiers consisting of only digits are compared numerically and
-identifiers with letters or hyphens are compared lexically in ASCII sort order.
-Numeric identifiers always have lower precedence than non-numeric identifiers.
+patch versions are always compared numerically. Pre-release precedence MUST be
+determined by comparing each dot separated identifier as follows: identifiers
+consisting of only digits are compared numerically and identifiers with
+letters or hyphens are compared lexically in ASCII sort order. Numeric
+identifiers always have lower precedence than non-numeric identifiers.
 Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-beta.2 < 1.0.0-beta.11 <
-1.0.0-rc.1 < 1.0.0-rc.1+build.1 < 1.0.0 < 1.0.0+0.3.7 < 1.3.7+build <
-1.3.7+build.2.b8f12d7 < 1.3.7+build.11.e0f985a.
+1.0.0-rc.1 < 1.0.0.
 
 Why Use Semantic Versioning?
 ----------------------------

--- a/semver.md
+++ b/semver.md
@@ -79,12 +79,13 @@ MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-]. Pre-release
 versions satisfy but have a lower precedence than the associated normal
 version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92.
 
-1. Build metadata MAY be denoted by appending a plus + and a series of dot 
+1. Build metadata MAY be denoted by appending a plus sign and a series of dot 
 separated identifiers immediately following the patch or pre-release version. 
 Identifiers MUST be comprised of only ASCII alphanumerics and hyphen 
 [0-9A-Za-z-]. Build metadata SHOULD be ignored when determining version 
 precedence. Thus two packages with the same version, but different build 
-metadata are considered to be the same version.
+metadata are considered to be the same version. Examples: 1.0.0-alpha+001, 
+1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85.
 
 1. Precedence MUST be calculated by separating the version into major, minor,
 patch and pre-release identifiers in that order (Build metadata does not figure 


### PR DESCRIPTION
Build metadata is a completely optional way to tack on metadata to a version  that does not affect the public API or precedence while still be compliant with SemVer. It's similar to a comment.

This allows folks to build on additional meaning or behavior that's meaningful to their custom systems without making any claims about the public version. For example, folks might use it for cache busting, layering custom behavior on top of SemVer, bookkeeping to tie when and
where a build was made, etc.

This PR is related to #61 and supersedes PR #70. You can see the previous discussions over there.
