### PR TITLE
"satisfies" → "are compatible with"

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -76,8 +76,9 @@ version is incremented.
 1. A pre-release version MAY be denoted by appending a hyphen and a series of
 dot separated identifiers immediately following the patch version. Identifiers
 MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-]. Pre-release
-versions satisfy but have a lower precedence than the associated normal
-version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92.
+versions are compatible with but have a lower precedence than the associated 
+normal version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 
+1.0.0-x.7.z.92.
 
 1. Build metadata MAY be denoted by appending a plus sign and a series of dot 
 separated identifiers immediately following the patch or pre-release version. 


### PR DESCRIPTION
Replaces "Pre-release versions satisfy but have a lower precedence than the associated normal version." with"Pre-release versions are compatible with but have a lower precedence than the associated normal version." to remove ambiguity, as per issue #86.
