### PR TITLE
Mark 2.0.0 as RTM (remove prerelease label)

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -1,4 +1,4 @@
-Semantic Versioning 2.0.0-rc.2
+Semantic Versioning 2.0.0
 ==============================
 
 Summary


### PR DESCRIPTION
This is based on the changes from #92 (which provides the summary).
