### PR TITLE
Clarify version comparisons

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -92,17 +92,23 @@ packages with the same version, but different build metadata are considered to
 be the same version. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700, 
 1.0.0-beta+exp.sha.5114f85.
 
-1. Precedence MUST be calculated by separating the version into major, minor,
-patch and pre-release identifiers in that order (Build metadata does not figure 
-into precedence). Major, minor, and patch versions are always compared 
-numerically. Pre-release precedence MUST be determined by comparing each dot 
-separated identifier as follows: identifiers consisting of only digits are 
-compared numerically and identifiers with letters or hyphens are compared 
+1. Precedence refers to how versions are compared to each other when ordered.
+Precedence MUST be calculated by separating the version into major, minor, patch
+and pre-release identifiers in that order (Build metadata does not figure 
+into precedence). Precedence is determined by the first difference when
+comparing each of these identifiers from left to right as follows: Major, minor,
+and patch versions are always compared numerically. Example: 1.0.0 < 2.0.0 <
+2.1.0 < 2.1.1. When major, minor, and patch are equal, a pre-release version has
+lower precedence than a normal version. Example: 1.0.0-alpha < 1.0.0. Precedence
+for two pre-release versions with the same major, minor, and patch version MUST
+be determined by comparing each dot separated identifier from left to right
+until a difference is found as follows: identifiers consisting of only digits
+are compared numerically and identifiers with letters or hyphens are compared
 lexically in ASCII sort order. Numeric identifiers always have lower precedence
-than non-numeric identifiers. A larger set of pre-release fields has a
-higher precedence than a smaller set, if all of the existing fields are
-equal. Example: 1.0.0-alpha < 1.0.0-alpha.beta < 1.0.0-alpha.1 <
-1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
+than non-numeric identifiers. A larger set of pre-release fields has a higher
+precedence than a smaller set, if all of the preceding identifiers are equal.
+Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta <
+1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
 
 Why Use Semantic Versioning?
 ----------------------------


### PR DESCRIPTION
This is cherry picked from #103 and attempts to clarify precedence.

This clarifies a couple of things.
1. How to compare pre-release versions with differing number of identifiers.
2. How the left-to-right comparison of identifiers relates to the comparison of the whole version.

For example, while the following is implied because it's so obvious, SemVer never really made it clear that 1.9.0 < 2.1.1. It only specifies how each identifier is compared.

The second commit in this PR attempts to clarify how the comparison of each identifier relates to the comparison of the whole version. Does this seem necessary or is it implied elsewhere? Can the language be improved?

/cc @isaacs
