### PR TITLE
Build metadata clarification

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -88,9 +88,9 @@ associated normal version. Examples: 1.0.0-alpha, 1.0.0-alpha.1,
 separated identifiers immediately following the patch or pre-release version. 
 Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-]. 
 Identifiers MUST NOT be empty. Build metadata SHOULD be ignored when determining
-version precedence. Thus two packages with the same version, but different build
-metadata, have the same precedence. Examples: 1.0.0-alpha+001, 
-1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85.
+version precedence. Thus two versions that differ only in the build metadata, 
+have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700, 
+1.0.0-beta+exp.sha.5114f85.
 
 1. Precedence refers to how versions are compared to each other when ordered.
 Precedence MUST be calculated by separating the version into major, minor, patch


### PR DESCRIPTION
Original commit clarifies language around build metadata precedence:

"They're not the 'same version', necessarily, they're the same precedence"

Second commit clarifies a bit more.
- Build metadata identifiers MUST not be empty.
- Changed "are" to "have" when discussing version precedence. We usually say a version HAS a precedence not that it IS a precedence.
