### PR TITLE
Mark 2.0.0 as RTM

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -1,4 +1,4 @@
-Semantic Versioning 2.0.0-rc.2
+Semantic Versioning 2.0.0
 ==============================
 
 Summary


### PR DESCRIPTION
Getting ready to ship this. I'll probably do it tomorrow. This just removes the `-rc.2` pre-release label form the spec.
