### PR TITLE
Making it clear how 0.X.Y versions work

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -69,7 +69,7 @@ Each element MUST increase numerically. For instance: 1.9.0 -> 1.10.0 -> 1.11.0.
 MUST NOT be modified. Any modifications MUST be released as a new version.
 
 1. Major version zero (0.y.z) is for initial development and SHOULD NOT be 
-considered for public consumtion. Avoid distribution to avoid dependency
+considered for public consumption. Avoid distribution to avoid dependency
 on an unstable API.
 
 1. Version 1.0.0 defines the public API. The way in which the version number

--- a/semver.md
+++ b/semver.md
@@ -68,9 +68,9 @@ Each element MUST increase numerically. For instance: 1.9.0 -> 1.10.0 -> 1.11.0.
 1. Once a versioned package has been released, the contents of that version
 MUST NOT be modified. Any modifications MUST be released as a new version.
 
-1. Major version zero (0.y.z) is for initial development and shouldn't be 
+1. Major version zero (0.y.z) is for initial development and SHOULD NOT be 
 considered for public consumtion. Avoid distribution to avoid dependency
-on unstable API.
+on an unstable API.
 
 1. Version 1.0.0 defines the public API. The way in which the version number
 is incremented after this release is dependent on this public API and how it

--- a/semver.md
+++ b/semver.md
@@ -68,8 +68,9 @@ Each element MUST increase numerically. For instance: 1.9.0 -> 1.10.0 -> 1.11.0.
 1. Once a versioned package has been released, the contents of that version
 MUST NOT be modified. Any modifications MUST be released as a new version.
 
-1. Major version zero (0.y.z) is for initial development. Anything may change
-at any time. The public API should not be considered stable.
+1. Major version zero (0.y.z) is for initial development and shouldn't be 
+considered for public consumtion. Avoid distribution to avoid dependency
+on unstable API.
 
 1. Version 1.0.0 defines the public API. The way in which the version number
 is incremented after this release is dependent on this public API and how it


### PR DESCRIPTION
I've come up against a lot of libraries that stick to 0.X.Y versions and when challenged claim "oh we might change the API". SEMVER is supposed to give you the freedom to change your public API as long as you document the severity of that change in the version. This line gives developers something to hide behind to avoid the scary 1.X.Y declaration when in reality they're well past a stable release and being depended on by others.

I find this to be both annoying and detrimental to the use of Semantic Versioning. One major point of SEMVER is that *APIs can safely change as long as a corresponding change happens to their Version*.

As such I've removed the wording "api can change" because it's not descriptive of 0.X.Y. 0.X.Y should be simple: If you're still working on minimum viable functionality then you're still 0.X.Y. As soon as someone depends on you, then you should document your public API and bump the major version to 1.X.Y.