### PR TITLE
Switched from Lexical Sort to Natural Sort

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -95,12 +95,13 @@ version is incremented.
 series of dot separated identifiers immediately following the patch
 version. Identifiers MUST comprise only ASCII alphanumerics and hyphen
 [0-9A-Za-z-]. Identifiers MUST NOT be empty. Numeric identifiers MUST
-NOT include leading zeroes. Pre-release versions have a lower
-precedence than the associated normal version. A pre-release version
-indicates that the version is unstable and might not satisfy the
-intended compatibility requirements as denoted by its associated
-normal version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7,
-1.0.0-x.7.z.92.
+NOT include leading zeroes. If an identifier ends with numerals then those
+numerals MUST be considered as a separate numeric identifier. Pre-release
+versions have a lower precedence than the associated normal version. A
+pre-release version indicates that the version is unstable and might not
+satisfy the intended compatibility requirements as denoted by its associated
+normal version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-alpha1, 1.0.0-rc2
+1.0.0-0.3.7, 1.0.0-x.7.z.92.
 
 1. Build metadata MAY be denoted by appending a plus sign and a series of dot
 separated identifiers immediately following the patch or pre-release version.
@@ -122,11 +123,13 @@ for two pre-release versions with the same major, minor, and patch version MUST
 be determined by comparing each dot separated identifier from left to right
 until a difference is found as follows: identifiers consisting of only digits
 are compared numerically and identifiers with letters or hyphens are compared
-using natural sort order. Numeric identifiers always have lower precedence
-than non-numeric identifiers. A larger set of pre-release fields has a higher
-precedence than a smaller set, if all of the preceding identifiers are equal.
-Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta <
-1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-Beta2 < 1.0.0-beta11 < 1.0.0-rc.1 < 1.0.0.
+using natural sort order. Natural sort is an case insensitive alphabetic sort
+that treats any trailing numbers as individual identifiers. Numeric identifiers
+always have lower precedence than non-numeric identifiers. A larger set of
+pre-release fields has a higher precedence than a smaller set, if all of the
+preceding identifiers are equal. Example: 1.0.0-alpha < 1.0.0-alpha.1 <
+1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-Beta2
+< 1.0.0-beta11 < 1.0.0-rc.1 < 1.0.0.
 
 Backus–Naur Form Grammar for Valid SemVer Versions
 --------------------------------------------------

--- a/semver.md
+++ b/semver.md
@@ -122,11 +122,11 @@ for two pre-release versions with the same major, minor, and patch version MUST
 be determined by comparing each dot separated identifier from left to right
 until a difference is found as follows: identifiers consisting of only digits
 are compared numerically and identifiers with letters or hyphens are compared
-lexically in ASCII sort order. Numeric identifiers always have lower precedence
+using natural sort order. Numeric identifiers always have lower precedence
 than non-numeric identifiers. A larger set of pre-release fields has a higher
 precedence than a smaller set, if all of the preceding identifiers are equal.
 Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta <
-1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
+1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-Beta2 < 1.0.0-beta11 < 1.0.0-rc.1 < 1.0.0.
 
 Backus–Naur Form Grammar for Valid SemVer Versions
 --------------------------------------------------


### PR DESCRIPTION
This change better first with people’s expectations. This way
1.0.0-beta2 has a lower precedence than 1.0.0-beta11, because “2” is
smaller than “11”- a point missed by lexical sorting. It also solves
the alphabetical issue  because natural sorting is essentially case
insensitive (it may or may not make sense to specify that two versions
of the same exact name but different cases is frowned upon, in which
case it’s case sensitive for our purposes).