### PR TITLE
Versions are not case sensitive

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -1,4 +1,4 @@
-Semantic Versioning 2.0.0
+Semantic Versioning 2.0.1
 ==============================
 
 Summary
@@ -122,11 +122,11 @@ for two pre-release versions with the same major, minor, and patch version MUST
 be determined by comparing each dot separated identifier from left to right
 until a difference is found as follows: identifiers consisting of only digits
 are compared numerically and identifiers with letters or hyphens are compared
-lexically in ASCII sort order. Numeric identifiers always have lower precedence
-than non-numeric identifiers. A larger set of pre-release fields has a higher
-precedence than a smaller set, if all of the preceding identifiers are equal.
-Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta <
-1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
+lexically in ASCII sort order but without case sensitivity. Numeric identifiers
+always have lower precedence than non-numeric identifiers. A larger set of
+pre-release fields has a higher precedence than a smaller set, if all of the
+preceding identifiers are equal. Example: 1.0.0-alpha < 1.0.0-Alpha.1 <
+1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-BETA.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
 
 Backus–Naur Form Grammar for Valid SemVer Versions
 --------------------------------------------------
@@ -310,6 +310,13 @@ that users can smoothly transition to the new API.
 No, but use good judgment. A 255 character version string is probably overkill,
 for example. Also, specific systems may impose their own limits on the size of
 the string.
+
+### Are SemVer pre-release labels and build metadata case-sensitive?
+
+No, they are not case-sensitive. In practice, standardizing on lower-case
+pre-release labels and build metadata can be beneficial, especially when
+cross-platform scenarios are considered. Systems must be case-insensitive when
+comparing and ordering pre-release labels and when comparing build metadata.
 
 About
 -----

--- a/semver.md
+++ b/semver.md
@@ -1,4 +1,4 @@
-Semantic Versioning 2.0.1
+Semantic Versioning 2.1.0
 ==============================
 
 Summary

--- a/semver.md
+++ b/semver.md
@@ -121,12 +121,12 @@ lower precedence than a normal version. Example: 1.0.0-alpha < 1.0.0. Precedence
 for two pre-release versions with the same major, minor, and patch version MUST
 be determined by comparing each dot separated identifier from left to right
 until a difference is found as follows: identifiers consisting of only digits
-are compared numerically and identifiers with letters or hyphens are compared
-lexically in ASCII sort order but without case sensitivity. Numeric identifiers
-always have lower precedence than non-numeric identifiers. A larger set of
-pre-release fields has a higher precedence than a smaller set, if all of the
-preceding identifiers are equal. Example: 1.0.0-alpha < 1.0.0-Alpha.1 <
-1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-BETA.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
+are compared numerically and identifiers with letters or hyphens are compared in
+a case-insensitive lexical ASCII sort order. Numeric identifiers always have
+lower precedence than non-numeric identifiers. A larger set of pre-release
+fields has a higher precedence than a smaller set, if all of the preceding
+identifiers are equal. Example: 1.0.0-alpha < 1.0.0-Alpha.1 < 1.0.0-alpha.beta <
+1.0.0-beta < 1.0.0-BETA.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.
 
 Backus–Naur Form Grammar for Valid SemVer Versions
 --------------------------------------------------


### PR DESCRIPTION
Fixes #176
Continued from #177

Note that even though this is technically a breaking change, _every_ change is a breaking change. The question is really how likely is this to break people.

The chances that people rely on capitalization for version precedence seems highly unlikely.

Also, SemVer applies to libraries, not necessarily specifications. Though I would agree that a library based on SemVer would probably want to increment the major version possibly putting it out of sync with the version of this spec.

Software is messy, isn't it?
