### PR TITLE
Clarify language about higher/lower precedence

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -94,12 +94,12 @@ version is incremented.
 series of dot separated identifiers immediately following the patch
 version. Identifiers MUST comprise only ASCII alphanumerics and hyphens
 [0-9A-Za-z-]. Identifiers MUST NOT be empty. Numeric identifiers MUST
-NOT include leading zeroes. Pre-release versions have a lower
-precedence than the associated normal version. A pre-release version
-indicates that the version is unstable and might not satisfy the
-intended compatibility requirements as denoted by its associated
-normal version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7,
-1.0.0-x.7.z.92, 1.0.0-x-y-z.--.
+NOT include leading zeroes. When determining version precedence, a version with
+a pre-release identifier has higher precedence than the same version without a
+pre-release identifier. A pre-release version indicates that the version is
+unstable and might not satisfy the intended compatibility requirements as
+denoted by its associated normal version. Examples: 1.0.0-alpha, 1.0.0-alpha.1,
+1.0.0-0.3.7, 1.0.0-x.7.z.92, 1.0.0-x-y-z.--.
 
 1. Build metadata MAY be denoted by appending a plus sign and a series of dot
 separated identifiers immediately following the patch or pre-release version.
@@ -121,7 +121,7 @@ have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700,
 
       Example: 1.0.0 < 2.0.0 < 2.1.0 < 2.1.1.
 
-   1. When major, minor, and patch are equal, a pre-release version has lower
+   1. When major, minor, and patch are equal, a pre-release version has higher
       precedence than a normal version:
 
       Example: 1.0.0-alpha < 1.0.0.
@@ -135,10 +135,10 @@ have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700,
       1. Identifiers with letters or hyphens are compared lexically in ASCII
          sort order.
 
-      1. Numeric identifiers always have lower precedence than non-numeric
+      1. Numeric identifiers always have higher precedence than non-numeric
          identifiers.
 
-      1. A larger set of pre-release fields has a higher precedence than a
+      1. A larger set of pre-release fields has a lower precedence than a
          smaller set, if all of the preceding identifiers are equal.
 
       Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 


### PR DESCRIPTION
I don't *think* this requires an RFC, since I consider it a clarification of semantics rather than changing semantics, but please correct me if anybody thinks otherwise.

The document seems to conflate "higher precedence" and "lower precedence". The term "higher precedence" is roughly equivalent to the terms "precedes" or "ordered before". E.g. in the sentence, "When major, minor, and patch are equal, a pre-release version has lower precedence than a normal version", it should really say "higher precedence".

A source of confusion may be that, on the topic of determining the order of some string composed of elements, the word "precedence" can commonly refer to two closely related but opposite things: 1. The order in which elements should be compared, and 2. The way some given strings should be ordered as a result of that. E.g. when comparing elements, the pre-release identifier has *lower precedence* than the "normal" version numbers, but when ordering versions, one with a pre-release identifier has *higher precedence* than the same "normal" version alone. Which of those two concepts is being referred to is usually clear by context, but I think an exception is this sentence: "Pre-release versions have a lower precedence than the associated normal version." That is why, in addition to the higher<->lower change described above, I've also added clarifying language to this sentence.

Note that the clarifying language in that sentence would be obviated and future confusion about higher vs lower precedence avoided if the document used some other term, like "ordered before/after", instead of the term "higher/lower precedence", but that would be a larger change.
