### PR TITLE
Clarify build metadata examples in spec item 10

### DIFF
--- a/semver.md
+++ b/semver.md
@@ -104,10 +104,14 @@ normal version. Examples: 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7,
 1. Build metadata MAY be denoted by appending a plus sign and a series of dot
 separated identifiers immediately following the patch or pre-release version.
 Identifiers MUST comprise only ASCII alphanumerics and hyphens [0-9A-Za-z-].
-Identifiers MUST NOT be empty. Build metadata MUST be ignored when determining
-version precedence. Thus two versions that differ only in the build metadata,
-have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700,
-1.0.0-beta+exp.sha.5114f85, 1.0.0+21AF26D3\-\-\-\-117B344092BD.
+Identifiers MUST NOT be empty.
+
+   Build metadata MUST be ignored when determining version precedence. Thus two
+   versions that differ only in the build metadata have the same precedence.
+   Example: 1.0.0+001 and 1.0.0+20130313144700.
+
+   Examples of build metadata: 1.0.0+20130313144700, 1.0.0-alpha+001,
+   1.0.0-beta+exp.sha.5114f85, 1.0.0+21AF26D3\-\-\-\-117B344092BD.
 
 1. Precedence refers to how versions are compared to each other when ordered.
 


### PR DESCRIPTION
## Summary
- Separate build-metadata precedence guidance from the syntax examples in spec item 10.
- Illustrate equal precedence with stable versions that differ only in build metadata (`1.0.0+001` and `1.0.0+20130313144700`).
- Label the remaining strings as examples of build metadata syntax, including pre-release plus metadata forms.

Fixes #568. Follows the clarity direction discussed in #640.

## Test plan
- [x] `npm run lint` (remark on `semver.md`)
